### PR TITLE
Update `run-tests.ps1` to pass CI tests.

### DIFF
--- a/bin/run-tests.ps1
+++ b/bin/run-tests.ps1
@@ -1,29 +1,32 @@
 $tmpRoot = [System.IO.Path]::GetTempPath()
 $exercises = Get-ChildItem -Path $PSScriptRoot/../exercises/practice -Directory
 $failed = 0
-Foreach($exercise in $exercises)
-{
+
+Foreach($exercise in $exercises) {
+
     $tmpDirName = Join-Path $tmpRoot $exercise.Name
-    $tmpDir = New-Item -ItemType Directory -Path $tmpDirName
+    $tmpDir = New-Item -ItemType Directory -Path $tmpDirName -Force
+
     Get-ChildItem $exercise.FullName -Recurse -Include *.tests.ps1 | Copy-Item -Destination $tmpDir.FullName
-    $exampleSolutionFile = Get-ChildItem $exercise.FullName -Recurse -Include *.example.ps1
-    if ($null -eq $exampleSolutionFile)
-    {
-        Write-Output "Error: no example solution found"
+    $exampleSolutionFile = Get-ChildItem "$($exercise.FullName)/.meta/" -Recurse -Include *.example.ps1
+    
+    if ($null -eq $exampleSolutionFile) {
+        Write-Output "Error: no example solution found for $($exercise.Name)"
         exit 1
     }
+
     $solutionFile = Join-Path $tmpDir.FullName $exampleSolutionFile.Name.Replace("example.","")
     Copy-Item -Path $exampleSolutionFile.FullName -Destination $solutionFile
+
     Push-Location $tmpDir.FullName
     $result = Invoke-Pester $tmpDir.FullName -PassThru
     Pop-Location
-    if ($result.TotalCount -eq 0)
-    {
+
+    if ($result.TotalCount -eq 0) {
         Write-Output "Error: no tests run"
         exit 1
     }
-    elseif ($result.FailedCount -ne 0)
-    {
+    elseif ($result.FailedCount -ne 0) {
         $failed += $result.FailedCount
     }
 }


### PR DESCRIPTION
1. Corrected bracket placement to confirm with styling guide:
   * Reference: https://github.com/PoshCode/PowerShellPracticeAndStyle/blob/master/Style-Guide/Code-Layout-and-Formatting.md
   * Added newlines for better readability. (Maybe controvertial)
2. Added `-Force` to overwrite `/tmp/$tmpDirName` if it exists from running failed tests locally.
3. Hidden files (files prefixed with a `.` are handled differently on *nix platforms with Powershell.
	To correct not finding the example files I added the `/.meta/` to obtain the `$exampleSolutionFile`

closes #156
